### PR TITLE
Don't require test execution as sudo on non-linux systems

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -8,7 +8,7 @@ require 'set'
 
 include God
 
-if Process.uid != 0
+if Process.uid != 0 and RbConfig::CONFIG['host_os'] == "linux"
   abort <<-EOF
 \n
 *********************************************************************


### PR DESCRIPTION
I got annoyed with the tests telling me to run as sudo, because "linux only" tool tests require it.
