### PR TITLE
Small bug smtp.

### DIFF
--- a/lib/god/contacts/email.rb
+++ b/lib/god/contacts/email.rb
@@ -49,7 +49,7 @@ module God
       self.server_port = 25
       self.sendmail_path = '/usr/sbin/sendmail'
       self.sendmail_args = '-i -t'
-	  self.authtype = :plain
+	  self.server_authtype = :plain
 	  
       self.format = lambda do |name, from_email, from_name, to_email, to_name, message, time, priority, category, host|
         <<-EOF


### PR DESCRIPTION
I have encountered a small bug in god email notification (smtp). Attribute server_auth cannot be boolean (true or false) in Net::SMTP.start - so I replaced it with server_authtype which is a Symbol for smtp authentication method (plain, login or cram_md5). Sorry for intrusion, I'm new to Ruby and github, I hope I'm messing anything up.
