### PR TITLE
Slashproc poller fix

### DIFF
--- a/lib/god/system/slash_proc_poller.rb
+++ b/lib/god/system/slash_proc_poller.rb
@@ -84,7 +84,7 @@ module God
         stats[:kstkeip], stats[:signal], stats[:blocked], stats[:sigignore],
         stats[:sigcatch], stats[:wchan], stats[:nswap], stats[:cnswap],
         stats[:exit_signal], stats[:processor], stats[:rt_priority],
-        stats[:policy] = File.read("/proc/#{@pid}/stat").split
+        stats[:policy] = File.read("/proc/#{@pid}/stat").scan(/\(.*?\)|\w+/)
         stats
       end
     end


### PR DESCRIPTION
This is a fix for an issue where processes being monitored by god contain a space in their name.
