### PR TITLE
Use IO.print instead of IO.puts for logging

### DIFF
--- a/lib/god/simple_logger.rb
+++ b/lib/god/simple_logger.rb
@@ -32,7 +32,7 @@ module God
       
       time = Time.now.strftime(self.datetime_format)
       label = SEV_LABEL[level]
-      @io.puts("#{label[0..0]} [#{time}] #{label.rjust(5)}: #{msg}")
+      @io.print("#{label[0..0]} [#{time}] #{label.rjust(5)}: #{msg}\n")
     end
     
     def fatal(msg)


### PR DESCRIPTION
When having multiple threads logging to a IO stream sometimes the output messages weren't separated by a newline. This is because `IO.puts` writes the output message and after that writes the record separator, tipically newline, in two (or more) different calls.

I've changed to use `IO.print` sending the `\n` character instead.
