### PR TITLE
Support for ssl in http_response_code condition

### DIFF
--- a/test/test_conditions_http_response_code.rb
+++ b/test/test_conditions_http_response_code.rb
@@ -40,7 +40,7 @@ class TestHttpResponseCode < Test::Unit::TestCase
   
   def test_test_should_return_false_if_code_is_is_set_to_200_but_response_is_500
     c = valid_condition
-    Net::HTTP.expects(:start).yields(stub(:read_timeout= => nil, :get => stub(:code => 500)))
+    Net::HTTP.any_instance.expects(:start).yields(mock(:read_timeout= => nil, :get => mock(:code => 500)))
     assert_equal false, c.test
   end
   
@@ -49,13 +49,13 @@ class TestHttpResponseCode < Test::Unit::TestCase
       cc.code_is = nil
       cc.code_is_not = [200]
     end
-    Net::HTTP.expects(:start).yields(stub(:read_timeout= => nil, :get => stub(:code => 200)))
+    Net::HTTP.any_instance.expects(:start).yields(mock(:read_timeout= => nil, :get => mock(:code => 200)))
     assert_equal false, c.test
   end
   
   def test_test_should_return_true_if_code_is_is_set_to_200_and_response_is_200
     c = valid_condition
-    Net::HTTP.expects(:start).yields(stub(:read_timeout= => nil, :get => stub(:code => 200)))
+    Net::HTTP.any_instance.expects(:start).yields(mock(:read_timeout= => nil, :get => mock(:code => 200)))
     assert_equal true, c.test
   end
   
@@ -64,13 +64,13 @@ class TestHttpResponseCode < Test::Unit::TestCase
       cc.code_is = nil
       cc.code_is_not = [200]
     end
-    Net::HTTP.expects(:start).yields(stub(:read_timeout= => nil, :get => stub(:code => 500)))
+    Net::HTTP.any_instance.expects(:start).yields(mock(:read_timeout= => nil, :get => mock(:code => 500)))
     assert_equal true, c.test
   end
   
   def test_test_should_return_false_if_code_is_is_set_to_200_but_response_times_out
     c = valid_condition
-    Net::HTTP.expects(:start).raises(Timeout::Error, '')
+    Net::HTTP.any_instance.expects(:start).raises(Timeout::Error, '')
     assert_equal false, c.test
   end
   
@@ -79,13 +79,13 @@ class TestHttpResponseCode < Test::Unit::TestCase
       cc.code_is = nil
       cc.code_is_not = [200]
     end
-    Net::HTTP.expects(:start).raises(Timeout::Error, '')
+    Net::HTTP.any_instance.expects(:start).raises(Timeout::Error, '')
     assert_equal true, c.test
   end
   
   def test_test_should_return_false_if_code_is_is_set_to_200_but_cant_connect
     c = valid_condition
-    Net::HTTP.expects(:start).raises(Errno::ECONNREFUSED, '')
+    Net::HTTP.any_instance.expects(:start).raises(Errno::ECONNREFUSED, '')
     assert_equal false, c.test
   end
   
@@ -94,7 +94,7 @@ class TestHttpResponseCode < Test::Unit::TestCase
       cc.code_is = nil
       cc.code_is_not = [200]
     end
-    Net::HTTP.expects(:start).raises(Errno::ECONNREFUSED, '')
+    Net::HTTP.any_instance.expects(:start).raises(Errno::ECONNREFUSED, '')
     assert_equal true, c.test
   end
   
@@ -102,7 +102,7 @@ class TestHttpResponseCode < Test::Unit::TestCase
     c = valid_condition do |cc|
       cc.times = [2, 2]
     end
-    Net::HTTP.expects(:start).yields(stub(:read_timeout= => nil, :get => stub(:code => 200))).times(2)
+    Net::HTTP.any_instance.expects(:start).yields(stub(:read_timeout= => nil, :get => stub(:code => 200))).times(2)
     assert_equal false, c.test
     assert_equal true, c.test
   end


### PR DESCRIPTION
I added an optional argument 'ssl' for the http_response_code condition to allow monitoring https links. Cavat - It does not verify the certificate of the monitored site.
