### PR TITLE
God reports wrong memory usage for processes that have a fancy process title

### DIFF
--- a/lib/god/system/slash_proc_poller.rb
+++ b/lib/god/system/slash_proc_poller.rb
@@ -74,7 +74,15 @@ module God
       
       def stat
         stats = {}
-        stats[:pid], stats[:comm], stats[:state], stats[:ppid], stats[:pgrp],
+        proc_stats = File.read("/proc/#{@pid}/stat").split
+
+        stats[:pid] = proc_stats.shift
+
+        comm = [proc_stats.shift]
+        comm << proc_stats.shift while comm.first[0] == ?( and comm.last[-1] != ?)
+        stats[:comm] = comm.join(" ")
+
+        stats[:state], stats[:ppid], stats[:pgrp],
         stats[:session], stats[:tty_nr], stats[:tpgid], stats[:flags],
         stats[:minflt], stats[:cminflt], stats[:majflt], stats[:cmajflt],
         stats[:utime], stats[:stime], stats[:cutime], stats[:cstime],
@@ -84,7 +92,7 @@ module God
         stats[:kstkeip], stats[:signal], stats[:blocked], stats[:sigignore],
         stats[:sigcatch], stats[:wchan], stats[:nswap], stats[:cnswap],
         stats[:exit_signal], stats[:processor], stats[:rt_priority],
-        stats[:policy] = File.read("/proc/#{@pid}/stat").split
+        stats[:policy] = proc_stats
         stats
       end
     end


### PR DESCRIPTION
If the process title includes spaces then parsing `/proc/<pid>/stat` mixes up the keys in the stats hash. This causes god to report wrong memory and cpu usage for the process. My pull request fixes that.

I wasn't able to include tests since it isn't reproducible on Mac OS X and I couldn't even change the process title from inside a ruby process to include a space. The issue came up when I was creating a configuration for a Node application run by [Cluster](http://learnboost.github.com/cluster/).
