### PR TITLE
Remove call to deprecated `default_executable=` method (RubyGems 1.8+)

### DIFF
--- a/god.gemspec
+++ b/god.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
   s.require_paths = %w[lib ext]
 
   s.executables = ["god"]
-  s.default_executable = 'god'
   s.extensions = %w[ext/god/extconf.rb]
 
   s.rdoc_options = ["--charset=UTF-8"]


### PR DESCRIPTION
This method has been deprecated on the Specification class as of RubyGems 1.8. The executable name only needs to be inside of the executables Array
