### PR TITLE
Would it be so bad to call to_s on the env hash?

### DIFF
--- a/lib/god/process.rb
+++ b/lib/god/process.rb
@@ -317,7 +317,7 @@ module God
 
         if self.env && self.env.is_a?(Hash)
           self.env.each do |(key, value)|
-            ENV[key] = value
+            ENV[key] = value.to_s
           end
         end
 


### PR DESCRIPTION
Would it be so bad to call to_s on the ENV values...? That way people could use integers as well without having to think about the fact that it MUST be a string or will blow up with a strange error?
