### PR TITLE
Add support for UTF8 Charset

### DIFF
--- a/bin/god
+++ b/bin/god
@@ -19,7 +19,7 @@ begin
     opts.banner = <<-EOF
   Usage:
     Starting:
-      god [-c <config file>] [-p <port> | -b] [-P <file>] [-l <file>] [-D]
+      god [-c <config file>] [-p <port> | -b] [-P <file>] [-l <file>] [-D] [-U]
       
     Querying:
       god <command> <argument> [-p <port>]
@@ -67,6 +67,11 @@ begin
     
     opts.on("-D", "--no-daemonize", "Don't daemonize") do
       options[:daemonize] = false
+    end
+    
+    # The tweet-text gem needs this in ruby < 1.8
+    opts.on("-U", "--utf8-charset", "Use UTF-8 character set (sets $KCODE to UTF8)") do
+      options[:utf8] = true
     end
     
     opts.on("-v", "--version", "Print the version number and exit") do

--- a/lib/god/cli/run.rb
+++ b/lib/god/cli/run.rb
@@ -16,6 +16,10 @@ module God
           require 'god/sys_logger'
         end
         
+        if @options[:utf8]
+          $KCODE = 'UTF8'
+        end
+        
         # run
         if @options[:daemonize]
           run_daemonized


### PR DESCRIPTION
Hi,

I have added a command line parameter (-U) that will set the $KCODE variable to UTF8.

The tweet-stream gem, which is a dependency of the latest twitter gem, requires that $KCODE be set to "UTF8".

Cheers
Peter
