### PR TITLE
Add syslog_facility configurability support for SysLogger

### DIFF
--- a/bin/god
+++ b/bin/god
@@ -20,13 +20,13 @@ begin
   Usage:
     Starting:
       god [-c <config file>] [-p <port> | -b] [-P <file>] [-l <file>] [-D]
-      
+
     Querying:
       god <command> <argument> [-p <port>]
       god <command> [-p <port>]
       god -v
       god -V (must be run as root to be accurate on Linux)
-      
+
     Commands:
       start <task or group name>         start task or group
       restart <task or group name>       restart task or group
@@ -41,70 +41,70 @@ begin
       quit                               stop god
       terminate                          stop god and all tasks
       check                              run self diagnostic
-      
+
     Options:
   EOF
-  
+
     opts.on("-cCONFIG", "--config-file CONFIG", "Configuration file") do |x|
       options[:config] = x
     end
-    
+
     opts.on("-pPORT", "--port PORT", "Communications port (default 17165)") do |x|
       options[:port] = x
     end
-    
+
     opts.on("-b", "--auto-bind", "Auto-bind to an unused port number") do
       options[:port] = "0"
     end
-    
+
     opts.on("-PFILE", "--pid FILE", "Where to write the PID file") do |x|
       options[:pid] = x
     end
-    
+
     opts.on("-lFILE", "--log FILE", "Where to write the log file") do |x|
       options[:log] = x
     end
-    
+
     opts.on("-D", "--no-daemonize", "Don't daemonize") do
       options[:daemonize] = false
     end
-    
+
     opts.on("-v", "--version", "Print the version number and exit") do
       options[:version] = true
     end
-    
+
     opts.on("-V", "Print extended version and build information") do
       options[:info] = true
     end
-    
+
     opts.on("--log-level LEVEL", "Log level [debug|info|warn|error|fatal]") do |x|
       options[:log_level] = x.to_sym
     end
-    
+
     opts.on("--no-syslog", "Disable output to syslog") do
       options[:syslog] = false
     end
-    
+
     opts.on("--attach PID", "Quit god when the attached process dies") do |x|
       options[:attach] = x
     end
-    
+
     opts.on("--no-events", "Disable the event system") do
       options[:events] = false
     end
-    
+
     opts.on("--bleakhouse", "Enable bleakhouse profiling") do
       options[:bleakhouse] = true
     end
   end
-  
+
   opts.parse!
-  
+
   # validate
   if options[:log_level] && ![:debug, :info, :warn, :error, :fatal].include?(options[:log_level])
     abort("Invalid log level '#{options[:log_level]}'")
   end
-  
+
   # dispatch
   if !options[:config] && options[:version]
     require 'god'

--- a/lib/god.rb
+++ b/lib/god.rb
@@ -115,15 +115,15 @@ end
 
 module Kernel
   alias_method :abort_orig, :abort
-  
+
   def abort(text = nil)
     $run = false
     applog(nil, :error, text) if text
     exit(1)
   end
-  
+
   alias_method :exit_orig, :exit
-  
+
   def exit(code = 0)
     $run = false
     exit_orig(code)
@@ -137,15 +137,15 @@ class Module
         if !self.running && self.inited
           abort "God.#{arg} must be set before any Tasks are defined"
         end
-        
+
         if self.running && self.inited
           applog(nil, :warn, "God.#{arg} can't be set while god is running")
           return
         end
-        
+
         instance_variable_set(('@' + arg.to_s).intern, other)
       end
-      
+
       define_method(arg) do
         instance_variable_get(('@' + arg.to_s).intern)
       end
@@ -163,7 +163,7 @@ module God
   TERMINATE_TIMEOUT_DEFAULT = 10
   STOP_TIMEOUT_DEFAULT = 10
   STOP_SIGNAL_DEFAULT = 'TERM'
-  
+
   class << self
     # user configurable
     safe_attr_accessor :pid,
@@ -179,7 +179,7 @@ module God
                        :socket_user,
                        :socket_group,
                        :socket_perms
-    
+
     # internal
     attr_accessor :inited,
                   :running,
@@ -192,7 +192,7 @@ module God
                   :contact_groups,
                   :main
   end
-  
+
   # initialize class instance variables
   self.pid = nil
   self.host = nil
@@ -205,14 +205,14 @@ module God
   self.socket_user = nil
   self.socket_group = nil
   self.socket_perms = 0755
-  
+
   # Initialize internal data.
   #
   # Returns nothing
   def self.internal_init
     # only do this once
     return if self.inited
-    
+
     # variable init
     self.watches = {}
     self.groups = {}
@@ -220,17 +220,17 @@ module God
     self.pending_watch_states = {}
     self.contacts = {}
     self.contact_groups = {}
-    
+
     # set defaults
     self.log_buffer_size ||= LOG_BUFFER_SIZE_DEFAULT
     self.port ||= DRB_PORT_DEFAULT
     self.allow ||= DRB_ALLOW_DEFAULT
     self.log_level ||= LOG_LEVEL_DEFAULT
     self.terminate_timeout ||= TERMINATE_TIMEOUT_DEFAULT
-    
+
     # additional setup
     self.setup
-    
+
     # log level
     log_level_map = {:debug => Logger::DEBUG,
                      :info => Logger::INFO,
@@ -238,14 +238,14 @@ module God
                      :error => Logger::ERROR,
                      :fatal => Logger::FATAL}
     LOG.level = log_level_map[self.log_level]
-    
+
     # init has been executed
     self.inited = true
-    
+
     # not yet running
     self.running = false
   end
-  
+
   # Instantiate a new, empty Watch object and pass it to the mandatory
   # block. The attributes of the watch will be set by the configuration
   # file.
@@ -258,7 +258,7 @@ module God
   def self.watch(&block)
     self.task(Watch, &block)
   end
-  
+
   # Instantiate a new, empty Task object and yield it to the mandatory
   # block. The attributes of the task will be set by the configuration
   # file.
@@ -270,13 +270,13 @@ module God
   # Returns nothing
   def self.task(klass = Task)
     self.internal_init
-    
+
     t = klass.new
     yield(t)
-    
+
     # do the post-configuration
     t.prepare
-    
+
     # if running, completely remove the watch (if necessary) to
     # prepare for the reload
     existing_watch = self.watches[t.name]
@@ -284,35 +284,35 @@ module God
       self.pending_watch_states[existing_watch.name] = existing_watch.state
       self.unwatch(existing_watch)
     end
-    
+
     # ensure the new watch has a unique name
     if self.watches[t.name] || self.groups[t.name]
       abort "Task name '#{t.name}' already used for a Task or Group"
     end
-    
+
     # ensure watch is internally valid
     t.valid? || abort("Task '#{t.name}' is not valid (see above)")
-    
+
     # add to list of watches
     self.watches[t.name] = t
-    
+
     # add to pending watches
     self.pending_watches << t
-    
+
     # add to group if specified
     if t.group
       # ensure group name hasn't been used for a watch already
       if self.watches[t.group]
         abort "Group name '#{t.group}' already used for a Task"
       end
-      
+
       self.groups[t.group] ||= []
       self.groups[t.group] << t
     end
-    
+
     # register watch
     t.register!
-    
+
     # log
     if self.running && existing_watch
       applog(t, :info, "#{t.name} Reloaded config")
@@ -320,7 +320,7 @@ module God
       applog(t, :info, "#{t.name} Loaded config")
     end
   end
-  
+
   # Unmonitor and remove the given watch from god.
   #   +watch+ is the Watch to remove
   #
@@ -328,21 +328,21 @@ module God
   def self.unwatch(watch)
     # unmonitor
     watch.unmonitor unless watch.state == :unmonitored
-    
+
     # unregister
     watch.unregister!
-    
+
     # remove from watches
     self.watches.delete(watch.name)
-    
+
     # remove from groups
     if watch.group
       self.groups[watch.group].delete(watch)
     end
-    
+
     applog(watch, :info, "#{watch.name} unwatched")
   end
-  
+
   # Instantiate a new Contact of the given kind and send it to the block.
   # Then prepare, validate, and record the Contact.
   #   +kind+ is the contact class specifier
@@ -355,7 +355,7 @@ module God
   # Returns nothing
   def self.contact(kind)
     self.internal_init
-    
+
     # verify contact has been loaded
     if CONTACT_LOAD_SUCCESS[kind] == false
       applog(nil, :error, "A required dependency for the #{kind} contact is unavailable.")
@@ -365,53 +365,53 @@ module God
       end
       abort
     end
-    
+
     # create the contact
     begin
       c = Contact.generate(kind)
     rescue NoSuchContactError => e
       abort e.message
     end
-    
+
     # send to block so config can set attributes
     yield(c) if block_given?
-    
+
     # call prepare on the contact
     c.prepare
-    
+
     # remove existing contacts of same name
     existing_contact = self.contacts[c.name]
     if self.running && existing_contact
       self.uncontact(existing_contact)
     end
-    
+
     # warn and noop if the contact has been defined before
     if self.contacts[c.name] || self.contact_groups[c.name]
       applog(nil, :warn, "Contact name '#{c.name}' already used for a Contact or Contact Group")
       return
     end
-    
+
     # abort if the Contact is invalid, the Contact will have printed
     # out its own error messages by now
     unless Contact.valid?(c) && c.valid?
       abort "Exiting on invalid contact"
     end
-    
+
     # add to list of contacts
     self.contacts[c.name] = c
-    
+
     # add to contact group if specified
     if c.group
       # ensure group name hasn't been used for a contact already
       if self.contacts[c.group]
         abort "Contact Group name '#{c.group}' already used for a Contact"
       end
-      
+
       self.contact_groups[c.group] ||= []
       self.contact_groups[c.group] << c
     end
   end
-  
+
   # Remove the given contact from god.
   #   +contact+ is the Contact to remove
   #
@@ -422,7 +422,7 @@ module God
       self.contact_groups[contact.group].delete(contact)
     end
   end
-  
+
   # Control the lifecycle of the given task(s).
   #   +name+ is the name of a task/group (String)
   #   +command+ is the command to run (String)
@@ -437,9 +437,9 @@ module God
   def self.control(name, command)
     # get the list of items
     items = Array(self.watches[name] || self.groups[name]).dup
-    
+
     jobs = []
-    
+
     # do the command
     case command
       when "start", "monitor"
@@ -455,12 +455,12 @@ module God
       else
         raise InvalidCommandError.new
     end
-    
+
     jobs.each { |j| j.join }
-    
+
     items.map { |x| x.name }
   end
-  
+
   # Unmonitor and stop all tasks.
   #
   # Returns true on success
@@ -472,15 +472,15 @@ module God
         w.action(:stop) if w.alive?
       end
     end
-    
+
     terminate_timeout.times do
       return true unless self.watches.map { |name, w| w.alive? }.any?
       sleep 1
     end
-    
+
     return false
   end
-  
+
   # Force the termination of god.
   #   * Clean up pid file if one exists
   #   * Stop DRb service
@@ -492,7 +492,7 @@ module God
     self.server.stop if self.server
     exit!(0)
   end
-  
+
   # Gather the status of each task.
   #
   # Examples
@@ -507,7 +507,7 @@ module God
     end
     info
   end
-  
+
   # Send a signal to each task.
   #   +name+ is the String name of the task or group
   #   +signal+ is the signal to send. e.g. HUP, 9
@@ -520,7 +520,7 @@ module God
     jobs.each { |j| j.join }
     items.map { |x| x.name }
   end
-  
+
   # Log lines for the given task since the specified time.
   #   +watch_name+ is the name of the task (may be abbreviated)
   #   +since+ is the Time since which to report log lines
@@ -530,14 +530,14 @@ module God
   # Returns String:joined_log_lines
   def self.running_log(watch_name, since)
     matches = pattern_match(watch_name, self.watches.keys)
-    
+
     unless matches.first
       raise NoSuchWatchError.new
     end
-    
+
     LOG.watch_log_since(matches.first, since)
   end
-  
+
   # Load a config file into a running god instance. Rescues any exceptions
   # that the config may raise and reports these back to the caller.
   #   +code+ is a String containing the config file
@@ -547,10 +547,10 @@ module God
   def self.running_load(code, filename)
     errors = ""
     watches = []
-    
+
     begin
       LOG.start_capture
-      
+
       Gem.clear_paths
       eval(code, root_binding, filename)
       self.pending_watches.each do |w|
@@ -569,17 +569,17 @@ module God
     rescue Exception => e
       # don't ever let running_load take down god
       errors << LOG.finish_capture
-      
+
       unless e.instance_of?(SystemExit)
         errors << e.message << "\n"
         errors << e.backtrace.join("\n")
       end
     end
-    
+
     names = watches.map { |x| x.name }
     [names, errors]
   end
-  
+
   # Load the given file(s) according to the given glob.
   #   +glob+ is the glob-enabled path to load
   #
@@ -589,7 +589,7 @@ module God
       Kernel.load f
     end
   end
-  
+
   def self.setup
     if self.pid_file_directory
       # pid file dir was specified, ensure it is created and writable
@@ -600,7 +600,7 @@ module God
           abort "Failed to create pid file directory: #{e.message}"
         end
       end
-      
+
       unless File.writable?(self.pid_file_directory)
         abort "The pid file directory (#{self.pid_file_directory}) is not writable by #{Etc.getlogin}"
       end
@@ -617,64 +617,58 @@ module God
         rescue Errno::EACCES => e
         end
       end
-      
+
       unless self.pid_file_directory
         dirs = PID_FILE_DIRECTORY_DEFAULTS.map { |x| File.expand_path(x) }
         abort "No pid file directory exists, could be created, or is writable at any of #{dirs.join(', ')}"
       end
     end
-    
-    if God::Logger.syslog
-      LOG.info("Syslog enabled.")
-    else
-      LOG.info("Syslog disabled.")
-    end
-    
+
     applog(nil, :info, "Using pid file directory: #{self.pid_file_directory}")
   end
-  
+
   # Initialize and startup the machinery that makes god work.
   #
   # Returns nothing
   def self.start
     self.internal_init
-    
+
     # instantiate server
     self.server = Socket.new(self.port, self.socket_user, self.socket_group, self.socket_perms)
-    
+
     # start monitoring any watches set to autostart
     self.watches.values.each { |w| w.monitor if w.autostart? }
-    
+
     # clear pending watches
     self.pending_watches.clear
-    
+
     # mark as running
     self.running = true
-    
+
     # don't exit
-    self.main = 
+    self.main =
     Thread.new do
       loop do
         sleep 60
       end
     end
-    
+
     self.main.join
   end
-  
+
   def self.version
     God::VERSION
   end
-  
+
   # To be called on program exit to start god
   #
   # Returns nothing
   def self.at_exit
     self.start
   end
-  
+
   # private
-  
+
   # Match a shortened pattern against a list of String candidates.
   # The pattern is expanded into a regular expression by
   # inserting .* between each character.
@@ -691,7 +685,7 @@ module God
   # Returns String[]:matched_elements
   def self.pattern_match(pattern, list)
     regex = pattern.split('').join('.*')
-    
+
     list.select do |item|
       item =~ Regexp.new(regex)
     end.sort_by { |x| x.size }

--- a/lib/god/cli/run.rb
+++ b/lib/god/cli/run.rb
@@ -1,21 +1,17 @@
 module God
   module CLI
-    
+
     class Run
       def initialize(options)
         @options = options
-        
+
         dispatch
       end
-      
+
       def dispatch
         # have at_exit start god
         $run = true
-        
-        if @options[:syslog]
-          require 'god/sys_logger'
-        end
-        
+
         # run
         if @options[:daemonize]
           run_daemonized
@@ -23,7 +19,7 @@ module God
           run_in_front
         end
       end
-      
+
       def attach
         process = System::Process.new(@options[:attach])
         Thread.new do
@@ -36,69 +32,74 @@ module God
           end
         end
       end
-      
+
       def default_run
         # make sure we have STDIN/STDOUT redirected immediately
         setup_logging
-        
+
         # start attached pid watcher if necessary
         if @options[:attach]
           self.attach
         end
-        
+
         if @options[:port]
           God.port = @options[:port]
         end
-        
+
         if @options[:events]
           God::EventHandler.load
         end
-        
+
         # set log level, defaults to WARN
         if @options[:log_level]
           God.log_level = @options[:log_level]
         else
           God.log_level = @options[:daemonize] ? :warn : :info
         end
-        
+
         if @options[:config]
           if !@options[:config].include?('*') && !File.exist?(@options[:config])
             abort "File not found: #{@options[:config]}"
           end
-          
+
           # start the event handler
           God::EventHandler.start if God::EventHandler.loaded?
-          
+
+          # Global config file
           load_config @options[:config]
         end
+
+        # Cmdline overrides for config
+        God::Logger.syslog = @options[:syslog]
+
         setup_logging
       end
-      
+
       def run_in_front
         require 'god'
-        
+
         if @options[:bleakhouse]
           BleakHouseDiagnostic.install
         end
-        
+
         default_run
       end
-      
+
       def run_daemonized
         # trap and ignore SIGHUP
         Signal.trap('HUP') {}
-        
+
         pid = fork do
           begin
             require 'god'
-            
+
             # set pid if requested
             if @options[:pid] # and as deamon
-              God.pid = @options[:pid] 
+              God.pid = @options[:pid]
             end
-            
+
             default_run
-            
+
             unless God::EventHandler.loaded?
               puts
               puts "***********************************************************************"
@@ -109,38 +110,44 @@ module God
               puts "***********************************************************************"
               puts
             end
-            
+
           rescue => e
             puts e.message
             puts e.backtrace.join("\n")
             abort "There was a fatal system error while starting god (see above)"
           end
         end
-        
+
         if @options[:pid]
           File.open(@options[:pid], 'w') { |f| f.write pid }
         end
-        
+
         ::Process.detach pid
-        
+
         exit
       end
-      
+
       def setup_logging
         log_file = God.log_file
         log_file = File.expand_path(@options[:log]) if @options[:log]
         log_file = "/dev/null" if !log_file && @options[:daemonize]
         if log_file
           puts "Sending output to log file: #{log_file}" unless @options[:daemonize]
-          
+
           # reset file descriptors
           STDIN.reopen "/dev/null"
           STDOUT.reopen(log_file, "a")
           STDERR.reopen STDOUT
           STDOUT.sync = true
         end
+
+        # Enable syslog
+        if Logger.syslog
+          require 'god/sys_logger'
+          applog(nil, :info, "Syslog enabled.")
+        end
       end
-      
+
       def load_config(config)
         files = File.directory?(config) ? Dir['**/*.god'] : Dir[config]
         abort "No files could be found" if files.empty?
@@ -150,7 +157,7 @@ module God
           end
         end
       end
-      
+
       def load_god_file(god_file)
         applog(nil, :info, "Loading #{god_file}")
         load File.expand_path(god_file)
@@ -165,8 +172,8 @@ module God
           false
         end
       end
-      
+
     end # Run
-    
+
   end
 end

--- a/lib/god/logger.rb
+++ b/lib/god/logger.rb
@@ -1,15 +1,13 @@
 module God
-  
+
   class Logger < SimpleLogger
 
     attr_accessor :logs
-    
+
     class << self
-      attr_accessor :syslog
+      attr_accessor :syslog, :syslog_facility
     end
-    
-    self.syslog = defined?(Syslog)
-    
+
     # Instantiate a new Logger object
     def initialize(io = $stdout)
       super(io)
@@ -21,13 +19,13 @@ module God
       @templog = SimpleLogger.new(@templogio)
       @templog.level = Logger::INFO
     end
-    
-    
+
+
     def level=(lev)
       SysLogger.level = SimpleLogger::CONSTANT_TO_SYMBOL[lev] if Logger.syslog
       super(lev)
     end
-    
+
     # Log a message
     #   +watch+ is the String name of the Watch (may be nil if not Watch is applicable)
     #   +level+ is the log level [:debug|:info|:warn|:error|:fatal]
@@ -61,7 +59,7 @@ module God
       # send to syslog
       SysLogger.log(level, text) if Logger.syslog
     end
-    
+
     # Get all log output for a given Watch since a certain Time.
     #   +watch_name+ is the String name of the Watch
     #   +since+ is the Time since which to fetch log lines
@@ -70,7 +68,7 @@ module God
     def watch_log_since(watch_name, since)
       # initialize watch log if necessary
       self.logs[watch_name] ||= Timeline.new(God::LOG_BUFFER_SIZE_DEFAULT)
-      
+
       # get and join lines since given time
       @mutex.synchronize do
         @spool = Time.now
@@ -81,9 +79,9 @@ module God
         end.join
       end
     end
-    
+
     # private
-    
+
     # Enable capturing of log
     #
     # Returns nothing
@@ -92,7 +90,7 @@ module God
         @capture = StringIO.new
       end
     end
-    
+
     # Disable capturing of log and return what was captured since
     # capturing was enabled with Logger#start_capture
     #
@@ -105,5 +103,4 @@ module God
       end
     end
   end
-  
 end

--- a/lib/god/sys_logger.rb
+++ b/lib/god/sys_logger.rb
@@ -1,15 +1,6 @@
 begin
   require 'syslog'
 
-  # Ensure that Syslog is open
-  begin
-    Syslog.open('god')
-  rescue RuntimeError
-    Syslog.reopen('god')
-  end
-
-  Syslog.info("Syslog enabled.")
-
   module God
 
     class SysLogger
@@ -35,6 +26,18 @@ begin
       #
       # Returns Nothing
       def self.log(level, text)
+        unless Syslog.opened?
+          facility = Syslog::LOG_USER
+          facility = God::Logger.syslog_facility if God::Logger.syslog_facility
+
+          # Ensure that Syslog is open
+          begin
+            Syslog.open('god', Syslog::LOG_PID | Syslog::LOG_CONS, facility)
+          rescue RuntimeError
+            Syslog.reopen('god', Syslog::LOG_PID | Syslog::LOG_CONS, facility)
+          end
+        end
+
         Syslog.log(SYMBOL_EQUIVALENTS[level], '%s', text)
       end
     end


### PR DESCRIPTION
Added support for God::Logger.syslog_facility in the file specifed by options[:config] at god startup. Required a bit of moving around of code. --no-syslog still overrides no matter the setting from config file. Did not add any lookup maps for Syslog constants, I prefer the method in the usage notes.

Usage notes (context of options[:config] file):
use 'syslog'
God::Logger.syslog_facility = LOG_LOCAL0

Review and let me know any concerns and I'll address. The 1st commit applies cleanly to the v0.11.0 tag if you want to backport.
