### PR TITLE
Remove Thread.join stubbing in test_god.rb

### DIFF
--- a/lib/god.rb
+++ b/lib/god.rb
@@ -658,10 +658,12 @@ module God
         sleep 60
       end
     end
-    
-    self.main.join
   end
-  
+
+  def self.join
+    self.main.join if self.main
+  end
+
   def self.version
     God::VERSION
   end
@@ -671,6 +673,7 @@ module God
   # Returns nothing
   def self.at_exit
     self.start
+    self.join
   end
   
   # private

--- a/test/test_god.rb
+++ b/test/test_god.rb
@@ -5,7 +5,6 @@ class TestGod < Test::Unit::TestCase
     God::Socket.stubs(:new).returns(true)
     God.stubs(:setup).returns(true)
     God.stubs(:validater).returns(true)
-    Thread.any_instance.stubs(:join).returns(true)
     God.reset
     God.pid_file_directory = '/var/run/god'
   end
@@ -273,7 +272,6 @@ class TestGod < Test::Unit::TestCase
     w = God.watches['foo']
     w.expects(:monitor)
     God.control('foo', 'start')
-    Thread.pass
   end
   
   def test_control_should_move_to_restart_on_restart
@@ -282,7 +280,6 @@ class TestGod < Test::Unit::TestCase
     w = God.watches['foo']
     w.expects(:move).with(:restart)
     God.control('foo', 'restart')
-    Thread.pass
   end
   
   def test_control_should_unmonitor_and_stop_on_stop
@@ -293,7 +290,6 @@ class TestGod < Test::Unit::TestCase
     w.expects(:unmonitor).returns(w)
     w.expects(:action).with(:stop)
     God.control('foo', 'stop')
-    Thread.pass
   end
   
   def test_control_should_unmonitor_on_unmonitor
@@ -303,7 +299,6 @@ class TestGod < Test::Unit::TestCase
     w.state = :up
     w.expects(:unmonitor).returns(w)
     God.control('foo', 'unmonitor')
-    Thread.pass
   end
   
   def test_control_should_unwatch_on_remove


### PR DESCRIPTION
Splits God.start into God.start and God.join to allow for testing of God.start
