### PR TITLE
netlink C ext: add PROC_EVENT_SID

### DIFF
--- a/ext/god/netlink_handler.c
+++ b/ext/god/netlink_handler.c
@@ -91,6 +91,9 @@ nlh_handle_events()
       case PROC_EVENT_EXEC:
       case PROC_EVENT_UID:
       case PROC_EVENT_GID:
+#ifdef PROC_EVENT_SID
+      case PROC_EVENT_SID:
+#endif
         break;
     }
   }


### PR DESCRIPTION
Apparently it didn't exist in 2.6.28 but got introduced later. Maybe it
makes sense to just add a default case to be future proof.

Since I fixed that, I wasn't able to reproduce issue #69
