### PR TITLE
Corrected usage of undefined local variable or method 'names'

### DIFF
--- a/lib/god/cli/command.rb
+++ b/lib/god/cli/command.rb
@@ -60,7 +60,7 @@ module God
         # output response
         unless affected.empty?
           puts 'The following tasks were affected:'
-          names.each do |w|
+          affected.each do |w|
             puts '  ' + w
           end
         end


### PR DESCRIPTION
On starting god I get the following error:

```
god: loading /etc/god/resque-web.god ...
Sending 'load' command with action 'leave'

The following tasks were affected:
Uncaught exception
undefined local variable or method `names' for #<God::CLI::Command:0x88394bc>
/home/deploy/.rbenv/versions/1.9.2-p290/lib/ruby/gems/1.9.1/gems/god-0.12.0/lib/god/cli/command.rb:63:in `load_command'
/home/deploy/.rbenv/versions/1.9.2-p290/lib/ruby/gems/1.9.1/gems/god-0.12.0/lib/god/cli/command.rb:30:in `dispatch'
/home/deploy/.rbenv/versions/1.9.2-p290/lib/ruby/gems/1.9.1/gems/god-0.12.0/lib/god/cli/command.rb:10:in `initialize'
/home/deploy/.rbenv/versions/1.9.2-p290/lib/ruby/gems/1.9.1/gems/god-0.12.0/bin/god:119:in `new'
/home/deploy/.rbenv/versions/1.9.2-p290/lib/ruby/gems/1.9.1/gems/god-0.12.0/bin/god:119:in `<top (required)>'
/home/deploy/.rbenv/versions/1.9.2-p290/bin/god:19:in `load'
/home/deploy/.rbenv/versions/1.9.2-p290/bin/god:19:in `<main>'
```

This change fixes the error, allowing god to start correctly.
