### PR TITLE
Provide a simple way to prevent bundler auto-loading

### DIFF
--- a/bin/god
+++ b/bin/god
@@ -105,7 +105,7 @@ begin
   end
 
   # Use this flag to actually load all of the god infrastructure
-  $should_really_load_god = true
+  $load_god = true
 
   # dispatch
   if !options[:config] && options[:version]

--- a/lib/god.rb
+++ b/lib/god.rb
@@ -2,7 +2,7 @@
 #
 # We are doing this to guard against bundler autoloading because there is
 # no value in loading god in most processes.
-if $should_really_load_god
+if $load_god
 
 # core
 require 'stringio'

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,7 +1,7 @@
 $:.unshift File.expand_path('../../lib', __FILE__) # For use/testing when no gem is installed
 
 # Use this flag to actually load all of the god infrastructure
-$should_really_load_god = true
+$load_god = true
 
 require File.join(File.dirname(__FILE__), *%w[.. lib god sys_logger])
 require File.join(File.dirname(__FILE__), *%w[.. lib god])


### PR DESCRIPTION
Most cases of problems we see with conflicts with sugar.rb are due to bundler
autoloading god into Rails processes when it really doesn't need to be.
