### PR TITLE
Multiple groups support

### DIFF
--- a/lib/god/process.rb
+++ b/lib/god/process.rb
@@ -301,7 +301,7 @@ module God
         File.umask self.umask if self.umask
         uid_num = Etc.getpwnam(self.uid).uid if self.uid
         gid_num = Etc.getgrnam(self.gid).gid if self.gid
-        gids_num = self.gids.map{|g| Etc.getgrnam(g).gid} if self.gids
+        gids_num = (self.gids || []).map{|g| Etc.getgrnam(g).gid}
 
         ::Dir.chroot(self.chroot) if self.chroot
         ::Process.setsid

--- a/test/test_process.rb
+++ b/test/test_process.rb
@@ -72,6 +72,22 @@ class TestProcessChild < Test::Unit::TestCase
     assert !@p.valid?
   end
 
+  def test_valid_should_return_true_if_gids_exists
+    @p.start = 'qux'
+    @p.log = '/tmp/foo.log'
+    @p.gids = %w{wheel root}
+
+    assert @p.valid?
+  end
+
+  def test_valid_should_return_false_if_gids_does_not_exists
+    @p.start = 'qux'
+    @p.log = '/tmp/foo.log'
+    @p.gids = %w{foobarbaz root}
+
+    assert !@p.valid?
+  end
+
   def test_valid_should_return_true_if_dir_exists
     @p.start = 'qux'
     @p.log = '/tmp/foo.log'


### PR DESCRIPTION
Allow a process to run under different groups

```
God.watch do |w|
  w.gid = "foo"
  w.gids = %w{bar rvm admin}
end
```
