### PR TITLE
Support for additional groups and basic expectations in sockets

### DIFF
--- a/lib/god/conditions/socket_responding.rb
+++ b/lib/god/conditions/socket_responding.rb
@@ -126,24 +126,24 @@ module God
           end
           status = s.nil?
         else
-          status = false
-        end
-
-        begin
-          timeout(expect_timeout) do
-            s.write(send_data) if send_data
-            if expect_data
-              line = s.readline.chop
-              if expect_data.is_a?(Regexp) && !expect_data.match(line) ||
-                 line != expect_data
-                self.info = "socket expected response does not match"
-                status = true
+          begin
+            timeout(expect_timeout) do
+              s.write(send_data) if send_data
+              if expect_data
+                line = s.readline.chop
+                if expect_data.is_a?(Regexp) && !expect_data.match(line) ||
+                   line != expect_data
+                  self.info = "socket expected response does not match"
+                  status = true
+                end
               end
             end
+          rescue Timeout::Error
+            self.info = "socket expect timeout"
+            status = true
+          else
+            status = false
           end
-        rescue Timeout::Error
-          self.info = "socket expect timeout"
-          status = true
         end
 
         @timeline.push(status)

--- a/lib/god/process.rb
+++ b/lib/god/process.rb
@@ -292,7 +292,7 @@ module God
 
         ::Dir.chroot(self.chroot) if self.chroot
         ::Process.setsid
-        ::Process.groups = [gid_num] if self.gid
+        ::Process.initgroups(self.uid, gid_num) if self.uid
         ::Process::Sys.setgid(gid_num) if self.gid
         ::Process::Sys.setuid(uid_num) if self.uid
         self.dir ||= '/'


### PR DESCRIPTION
Hello, you may want to consider the two commits I made which implement initialization of additional group membership while changing privileges and basic expectation rules on what the SocketResponding condition should read from a socket to consider it alive.
