### PR TITLE
The Ruby 1.9 fixes should only apply to 1.9.0 and 1.9.1.

### DIFF
--- a/lib/god/driver.rb
+++ b/lib/god/driver.rb
@@ -1,7 +1,7 @@
 require 'monitor'
 
-# Ruby 1.9 specific fixes.
-unless RUBY_VERSION < '1.9'
+# Ruby 1.9.1 specific fixes.
+if RUBY_VERSION.between?('1.9', '1.9.1')
   require 'god/compat19'
 end
 


### PR DESCRIPTION
They should never have been applied to 1.9.2 and above because these already include the fixes. Furthermore, the fixes actually break under Ruby 2.0.
