### PR TITLE
Added support for IRC notifications

### DIFF
--- a/god.gemspec
+++ b/god.gemspec
@@ -86,6 +86,7 @@ Gem::Specification.new do |s|
     lib/god/contacts/scout.rb
     lib/god/contacts/twitter.rb
     lib/god/contacts/webhook.rb
+    lib/god/contacts/irc.rb
     lib/god/driver.rb
     lib/god/errors.rb
     lib/god/event_handler.rb

--- a/lib/god.rb
+++ b/lib/god.rb
@@ -91,6 +91,7 @@ load_contact(:prowl)
 load_contact(:scout)
 load_contact(:twitter)
 load_contact(:webhook)
+load_contact(:irc)
 
 $:.unshift File.join(File.dirname(__FILE__), *%w[.. ext god])
 

--- a/lib/god/contacts/irc.rb
+++ b/lib/god/contacts/irc.rb
@@ -1,0 +1,44 @@
+# Send a notice to an IRC channel.
+#
+# host        - The String hostname of the IRC server.
+# port        - The Integer port of the IRC server.
+# channel     - The String IRC Channel.
+# nick        - The String Nickname of the sender.
+# realname    - The String Realname of the sender.
+
+module God
+  module Contacts
+    class Irc < Contact
+      class << self
+        attr_accessor :host, :port, :channel, :nick, :realname
+      end
+
+      def valid?
+        valid = true
+        valid &= complain("Attribute 'host' must be specified", self) unless arg(:host)
+        valid &= complain("Attribute 'port' must be specified", self) unless arg(:port)
+        valid &= complain("Attribute 'channel' must be specified", self) unless arg(:channel)
+        valid &= complain("Attribute 'nick' must be specified", self) unless arg(:nick)
+        valid &= complain("Attribute 'realname' must be specified", self) unless arg(:realname)
+        valid
+      end
+
+      attr_accessor :host, :port, :channel, :nick, :realname
+
+      def notify(message, time, priority, category, host)
+
+        s = TCPSocket.open(arg(:host), arg(:port))
+        s.puts("NICK #{arg(:nick)}")
+        s.puts("USER #{arg(:nick)} 8 * : #{arg(:realname)}")
+        s.puts "PRIVMSG #{arg(:channel)} :'" + message + "'"
+        s.close
+
+        self.info = "sent IRC update"
+
+      rescue => e
+        applog(nil, :info, "failed to send IRC update: #{e.message}")
+        applog(nil, :debug, e.backtrace.join("\n"))
+      end
+    end
+  end
+end


### PR DESCRIPTION
I added support for IRC Contacts / Notification.

```ruby
God.watch do |w|
  God.contact(:irc) do |c|
    c.name = 'irc'
    c.host = 'irc.freenode.org'
    c.port = 6667
    c.channel = '#mychannel'
    c.nick = 'its_me_god'
    c.realname = "God"
  end

  w.name = "my_task"
  w.start = "ruby do_random_stuff.rb"
  w.keepalive(:memory_max => 150.megabytes, :cpu_max => 50.percent)
  w.interval = 60.seconds
  w.behavior(:clean_pid_file)

  w.transition(:up, :restart) do |on|
    on.condition(:process_exits) do |c|
      c.notify = 'irc'
    end
  end
end
```