### PR TITLE
Prevent from starts two processes

### DIFF
--- a/lib/god/process.rb
+++ b/lib/god/process.rb
@@ -1,3 +1,5 @@
+require 'shellwords'
+
 module God
   class Process
     WRITES_PID = [:start, :restart]
@@ -321,7 +323,10 @@ module God
           end
         end
 
-        exec command unless command.empty?
+        unless command.empty?
+          args = Shellwords.split command
+          exec *args
+        end
       end
     end
 


### PR DESCRIPTION
``` bash
# before
sh -c ruby -e 'loop { p ARGV; sleep 1; }' 'foo bar'
 \_ ruby -e loop { p ARGV; sleep 1; } foo bar

# after
ruby -e loop { p ARGV; sleep 1; } foo bar
```
