### PR TITLE
process running condition informs running

### DIFF
--- a/lib/god/conditions/process_running.rb
+++ b/lib/god/conditions/process_running.rb
@@ -46,6 +46,7 @@ module God
         active = pid && System::Process.new(pid).exists?
 
         if (self.running && active)
+          self.info.concat(["process is running"])
           true
         elsif (!self.running && !active)
           self.info.concat(["process is not running"])


### PR DESCRIPTION
When using a notify in the condition of process running, you now get a message to identifying that the process is running
