### PR TITLE
[fix #129] Fix register/de-register bug when process is restarted out-of-band.

### DIFF
--- a/lib/god/conditions/process_exits.rb
+++ b/lib/god/conditions/process_exits.rb
@@ -28,7 +28,8 @@ module God
       end
 
       def pid
-        self.pid_file ? File.read(self.pid_file).strip.to_i : self.watch.pid
+        # only read pid once since lazy evaluation can cause bugs due to changing external state
+        @pid ||= self.pid_file ? File.read(self.pid_file).strip.to_i : self.watch.pid
       end
 
       def register
@@ -50,6 +51,8 @@ module God
 
       def deregister
         pid = self.pid
+        @pid = nil # reset so that @pid will bootstrap itself again as needed
+
         if pid
           EventHandler.deregister(pid, :proc_exit)
 


### PR DESCRIPTION
Fixes a bug when a process is restarted out-of-band wherby the
original pid was never unwatched and thus would trigger
false-positives by god on noticing process exits.

I am not 100% sure that this doesn't cause problems elsewhere. Not exactly sure how to test and don't know enough about the overall architecture to know what I don't know about how all this works across different process mechanisms.

In any case I'm going to use this on my prod box for a bit and see how it goes.

Would love to have additional feedback.
