### PR TITLE
Webhooks with URL's that contain query parameters

### DIFF
--- a/lib/god/contacts/webhook.rb
+++ b/lib/god/contacts/webhook.rb
@@ -47,10 +47,10 @@ module God
 
         case arg(:format)
           when :form
-            req = Net::HTTP::Post.new(uri.path)
+            req = Net::HTTP::Post.new(uri.request_uri)
             req.set_form_data(data)
           when :json
-            req = Net::HTTP::Post.new(uri.path)
+            req = Net::HTTP::Post.new(uri.request_uri)
             req.body = data.to_json
         end
 

--- a/test/test_webhook.rb
+++ b/test/test_webhook.rb
@@ -12,4 +12,11 @@ class TestWebhook < Test::Unit::TestCase
     @webhook.notify('msg', Time.now, 'prio', 'cat', 'host')
     assert_equal "sent webhook to http://example.com/switch", @webhook.info
   end
+
+  def test_notify_with_url_containing_query_parameters
+    @webhook.url = 'http://example.com/switch?api_key=123'
+    Net::HTTP::Post.expects(:new).with('/switch?api_key=123')
+
+    @webhook.notify('msg', Time.now, 'prio', 'cat', 'host')
+  end
 end


### PR DESCRIPTION
Hi,

I noticed that Webhooks with URL's that contain query parameters were not being correctly handled (in the cause of providing an API key for example).

This PR fixes that and a small typo in the message that is displayed when a webhook failed.

Thanks,

Ash.
