### PR TITLE
Fix fatal exception when pid is nil

### DIFF
--- a/lib/god/process.rb
+++ b/lib/god/process.rb
@@ -210,13 +210,19 @@ module God
           applog(self, :info, "#{self.name} sent SIG#{@stop_signal}")
 
           # Poll to see if it's dead
+          pid_not_found = false
           @stop_timeout.times do
-            begin
-              ::Process.kill(0, pid)
-            rescue Errno::ESRCH
-              # It died. Good.
-              applog(self, :info, "#{self.name} process stopped")
-              return
+            if pid
+              begin
+                ::Process.kill(0, pid)
+              rescue Errno::ESRCH
+                # It died. Good.
+                applog(self, :info, "#{self.name} process stopped")
+                return
+              end
+            else
+              applog(self, :warn, "#{self.name} pid not found in #{self.pid_file}") unless pid_not_found
+              pid_not_found = true
             end
 
             sleep 1


### PR DESCRIPTION
pid may return a nil value (if never found in pid_file) causing Process.kill to throw an exception (TypeError: no implicit conversion from nil to integer). We should check to make sure the pid isn't nil before attempting to kill it. Warn (once) about the missing pid. Don't interrupt polling in case a valid pid_file shows up while polling.
