### PR TITLE
Webhooks contact: allow SSL URIs

### DIFF
--- a/lib/god/contacts/webhook.rb
+++ b/lib/god/contacts/webhook.rb
@@ -41,6 +41,7 @@ module God
 
         uri = URI.parse(arg(:url))
         http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = true if uri.scheme == "https"
 
         req = nil
         res = nil


### PR DESCRIPTION
Currently using a webhook contact with an HTTPS URI will fail; since it's pretty common to find webhooks in the wild that function only over SSL, this is problematic.

This commit tells Net::HTTP to use SSL if the webhook URL we've been passed has a scheme of `https`; otherwise, it uses HTTP.

A tiny change, but it fixes the issue for me.
