### PR TITLE
Contact for Slack, the chat application

### DIFF
--- a/doc/god.asciidoc
+++ b/doc/god.asciidoc
@@ -1243,6 +1243,46 @@ end
 apikey - The String API key.
 ```
 
+Slack
+~~~~~
+
+Send a message to a channel in Slack (https://slack.com/).
+
+First, set up an Incoming Webhook in your Slack account.
+
+Then, in your God configuration, set the defaults:
+
+```ruby
+God::Contacts::Slack.defaults do |d|
+  d.account = "foo"
+  d.token = "abc123abc123abc123"
+  c.notify_channel = true
+  c.format = '%{host} alert: %{message}'
+end
+```
+
+`account` is the name of your Slack account; if you view slack at
+"foo.slack.com", then your account is "foo". `token` is from your
+newly-created webhook, and will be a string of unintelligible
+characters.
+
+The `notify_channel` and `format` settings are optional. The first
+controls whether the message includes `@channel` (sending notifications
+to everyone in the channel); the second controls how the message is
+formatted. Acceptable values within the format are `priority`, `host`,
+`message`, `category`, and `time`.
+
+Once you've set the defaults, create contacts for the channels that you
+want to notify. You can create as many as you like, and they'll look
+something like this:
+
+```ruby
+God.contact(:slack) do |c|
+  c.name = '#ops'
+  c.channel = '#ops'
+end
+```
+
 /////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////
 

--- a/lib/god.rb
+++ b/lib/god.rb
@@ -93,6 +93,7 @@ load_contact(:scout)
 load_contact(:twitter)
 load_contact(:webhook)
 load_contact(:airbrake)
+load_contact(:slack)
 
 $:.unshift File.join(File.dirname(__FILE__), *%w[.. ext god])
 

--- a/lib/god/contacts/slack.rb
+++ b/lib/god/contacts/slack.rb
@@ -1,0 +1,84 @@
+# Send a message to a Slack channel
+#
+# account        - The name of your Slack account (visible in URL, e.g. foo.slack.com)
+# token          - The token of the webhook created in Slack
+# channel        - The name of the channel to send the message to, prefixed with #
+# notify_channel - Whether to send an "@channel" in the message, to alert everyone in the channel
+# format         - An optional format string to change how the alert is displayed
+
+require 'net/http'
+require 'uri'
+
+CONTACT_DEPS[:slack] = ['json']
+CONTACT_DEPS[:slack].each do |d|
+  require d
+end
+
+module God
+  module Contacts
+
+    class Slack < Contact
+      class << self
+        attr_accessor :account, :token, :channel, :notify_channel, :format
+      end
+
+      self.channel        = "#general"
+      self.notify_channel = false
+      self.format         = "%{priority} alert on %{host}: %{message} (%{category}, %{time})"
+
+      def valid?
+        valid = true
+        valid &= complain("Attribute 'account' must be specified", self) unless arg(:account)
+        valid &= complain("Attribute 'token' must be specified", self) unless arg(:token)
+        valid
+      end
+
+      attr_accessor :account, :token, :channel, :notify_channel, :format
+
+      def text(data)
+        text = ""
+        text << "<!channel> " if arg(:notify_channel)
+        text << arg(:format) % data
+      end
+
+      def notify(message, time, priority, category, host)
+        text = text({
+          :message => message,
+          :time => time,
+          :priority => priority,
+          :category => category,
+          :host => host
+        })
+
+        request(text)
+      end
+
+      def api_url
+        URI.parse("https://#{arg(:account)}.slack.com/services/hooks/incoming-webhook?token=#{arg(:token)}&channel=#{arg(:channel)}")
+      end
+
+      def request(text)
+        http = Net::HTTP.new(api_url.host, api_url.port)
+        http.use_ssl = true
+
+        req = Net::HTTP::Post.new(api_url.request_uri)
+        req.body = { text: text }.to_json
+
+        res = http.request(req)
+
+        case res
+          when Net::HTTPSuccess
+            self.info = "successfully notified slack on channel #{arg(:channel)}"
+          else
+            self.info = "failed to send webhook to #{arg(:url)}: #{res.error!}"
+        end
+      rescue Object => e
+        applog(nil, :info, "failed to send webhook to #{arg(:url)}: #{e.message}")
+        applog(nil, :debug, e.backtrace.join("\n"))
+      end
+
+    end
+
+  end
+end
+

--- a/test/test_slack.rb
+++ b/test/test_slack.rb
@@ -1,0 +1,56 @@
+require File.dirname(__FILE__) + '/helper'
+
+class TestSlack < Test::Unit::TestCase
+  def setup
+    @slack = God::Contacts::Slack.new
+    @slack.account = "foo"
+    @slack.token = "foo"
+
+    @sample_data = {
+      :message => "a sample message",
+      :time => "2038-01-01 00:00:00",
+      :priority => "High",
+      :category => "Test",
+      :host => "example.com"
+    }
+  end
+
+  def test_api_url
+    assert_equal "https://foo.slack.com/services/hooks/incoming-webhook?token=foo&channel=#general", @slack.api_url.to_s
+  end
+
+  def test_notify
+    Net::HTTP.any_instance.expects(:request).returns(Net::HTTPSuccess.new('a', 'b', 'c'))
+
+    @slack.channel = "#ops"
+
+    @slack.notify('msg', Time.now, 'prio', 'cat', 'host')
+    assert_equal "successfully notified slack on channel #ops", @slack.info
+  end
+
+  def test_default_channel
+    Net::HTTP.any_instance.expects(:request).returns(Net::HTTPSuccess.new('a', 'b', 'c'))
+
+    @slack.notify('msg', Time.now, 'prio', 'cat', 'host')
+    assert_equal "successfully notified slack on channel #general", @slack.info
+  end
+
+  def test_default_formatting
+    text = @slack.text(@sample_data)
+    assert_equal "High alert on example.com: a sample message (Test, 2038-01-01 00:00:00)", text
+  end
+
+  def test_custom_formatting
+    @slack.format = "%{host}: %{message}"
+    text = @slack.text(@sample_data)
+    assert_equal "example.com: a sample message", text
+  end
+
+  def test_notify_channel
+    @slack.notify_channel = true
+    @slack.format = ""
+    text = @slack.text(@sample_data)
+    assert_equal "<!channel> ", text
+  end
+end
+


### PR DESCRIPTION
[Slack](https://slack.com/) is a popular team chat service that offers integration through webhooks. However, God's default webhooks don't work with it (since it requires different field names).

This commit adds a new Contact for Slack, allowing you to specify just an account name and webhook token in order to integrate God with Slack.

It also offers an easier configuration than trying to do it through a webhook, since you can specify the channels, message formats, etc. through the ordinary God contact configuration.

This PR includes unit tests for all newly-added functionality; these tests are passing for me on Ruby 1.9.3 (I can't get God's development dependencies to work for me on 2.0+, since `rcov` fails to build, so I had to test on 1.9.3, but I can't see anything that would break in later versions of Ruby).

Let me know if you have any questions!
