### PR TITLE
Slack contact fixes for Ruby <1.9

### DIFF
--- a/lib/god/contacts/slack.rb
+++ b/lib/god/contacts/slack.rb
@@ -38,7 +38,16 @@ module God
       def text(data)
         text = ""
         text << "<!channel> " if arg(:notify_channel)
-        text << arg(:format) % data
+
+        if RUBY_VERSION =~ /^1\.8/
+          text << arg(:format).gsub(/%{(\w+)}/) do |match|
+            data[$1.to_sym]
+          end
+        else
+          text << arg(:format) % data
+        end
+
+        text
       end
 
       def notify(message, time, priority, category, host)
@@ -62,7 +71,7 @@ module God
         http.use_ssl = true
 
         req = Net::HTTP::Post.new(api_url.request_uri)
-        req.body = { text: text }.to_json
+        req.body = { :text => text }.to_json
 
         res = http.request(req)
 


### PR DESCRIPTION
These changes fix the issues mentioned in #172.

They were:
- A new-style symbol-as-key hash rather than the old hashrocket style
- Use of the `%` string formatter with a hash as the value argument, which has
  only existed since 1.9

All tests are now passing for me on 1.8.7-p374 and 1.9.3-p545.
