### PR TITLE
Fix link for Prowl in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -614,9 +614,9 @@ PID file will be stored for it in <tt>/var/run/god</tt>.</p></div>
 <span class="no">God</span><span class="o">.</span><span class="n">watch</span> <span class="k">do</span> <span class="o">|</span><span class="n">w</span><span class="o">|</span>
   <span class="n">w</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="s1">'mongrel'</span>
   <span class="n">w</span><span class="o">.</span><span class="n">pid_file</span> <span class="o">=</span> <span class="n">w</span><span class="o">.</span><span class="n">pid_file</span> <span class="o">=</span> <span class="no">File</span><span class="o">.</span><span class="n">join</span><span class="p">(</span><span class="no">RAILS_ROOT</span><span class="p">,</span> <span class="s2">"log/mongrel.pid"</span><span class="p">)</span>
-  
+
   <span class="n">w</span><span class="o">.</span><span class="n">start</span> <span class="o">=</span> <span class="s2">"mongrel_rails start -P </span><span class="si">#{</span><span class="no">RAILS_ROOT</span><span class="si">}</span><span class="s2">/log/mongrel.pid  -d"</span>
-  
+
   <span class="c1"># ...</span>
 <span class="k">end</span>
 
@@ -624,9 +624,9 @@ PID file will be stored for it in <tt>/var/run/god</tt>.</p></div>
 <span class="no">God</span><span class="o">.</span><span class="n">watch</span> <span class="k">do</span> <span class="o">|</span><span class="n">w</span><span class="o">|</span>
   <span class="n">w</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="s1">'worker'</span>
   <span class="c1"># w.pid_file = is not set</span>
-  
+
   <span class="n">w</span><span class="o">.</span><span class="n">start</span> <span class="o">=</span> <span class="s2">"rake resque:worker"</span>
-  
+
   <span class="c1"># ...</span>
 <span class="k">end</span>
 </pre>
@@ -1046,7 +1046,7 @@ subject  - The String subject of the message (default: "God Notification").
 </div>
 <div class="sect2">
 <h3 id="wiki-_prowl">Prowl</h3>
-<div class="paragraph"><p>Send a notice to Prowl (&lt;a href="http://prowl.weks.net/"&gt;http://prowl.weks.net/&lt;/a&gt;).</p></div>
+<div class="paragraph"><p>Send a notice to Prowl (<a href="http://prowl.weks.net/">http://prowl.weks.net/</a>).</p></div>
 <div class="paragraph"><div class="highlight"><pre><span class="no">God</span><span class="o">::</span><span class="no">Contacts</span><span class="o">::</span><span class="no">Prowl</span><span class="o">.</span><span class="n">defaults</span> <span class="k">do</span> <span class="o">|</span><span class="n">d</span><span class="o">|</span>
   <span class="o">.</span><span class="n">.</span><span class="o">.</span>
 <span class="k">end</span>


### PR DESCRIPTION
Found an error while reading through the docs. The link to prowl was using escaped `<` and `>`
