### PR TITLE
Use rb_wait_for_single_fd instead of deprecated rb_thread_select

### DIFF
--- a/ext/god/extconf.rb
+++ b/ext/god/extconf.rb
@@ -9,6 +9,7 @@ def create_dummy_makefile
   end
 end
 
+have_func('rb_wait_for_single_fd')
 case RUBY_PLATFORM
 when /bsd/i, /darwin/i
   unless have_header('sys/event.h')

--- a/ext/god/kqueue_handler.c
+++ b/ext/god/kqueue_handler.c
@@ -5,6 +5,10 @@
 #include <sys/time.h>
 #include <errno.h>
 
+#ifdef HAVE_RB_WAIT_FOR_SINGLE_FD
+  #include <ruby/io.h>
+#endif
+
 static VALUE mGod;
 static VALUE cKQueueHandler;
 static VALUE cEventHandler;
@@ -63,6 +67,10 @@ kqh_handle_events()
 {
   int nevents, i, num_to_fetch;
   struct kevent *events;
+
+#ifdef HAVE_RB_WAIT_FOR_SINGLE_FD
+  rb_wait_for_single_fd(kq, RB_WAITFD_IN, NULL);
+#else
   fd_set read_set;
 
   FD_ZERO(&read_set);
@@ -70,7 +78,7 @@ kqh_handle_events()
 
   // Don't actually run this method until we've got an event
   rb_thread_select(kq + 1, &read_set, NULL, NULL, NULL);
-
+#endif
   // Grabbing num_events once for thread safety
   num_to_fetch = num_events;
   events = (struct kevent*)malloc(num_to_fetch * sizeof(struct kevent));

--- a/test/test_god.rb
+++ b/test/test_god.rb
@@ -15,6 +15,10 @@ class TestGod < MiniTest::Test
         w.driver.thread.kill
       end
     end
+    God.reset
+    #Some of the tests in this file intentionally set pid_file_directory to an invalid value
+    #This can cause a later test failure since God will call abort if pid_file_directory is not writable    
+    God.pid_file_directory = '~/.god/pids'
   end
 
   # applog


### PR DESCRIPTION
rb_thread_select has been removed in ruby 2.2 (see #194 for example). The old code will still be used if `rb_wait_for_single_fd` is not available (which I believe is since 1.9.3)

I've done a quick check that everything still works as intended (linux & os x) when using events, just using the `simple.rb` example in the god documentation.

There doesn't seem to be any test coverage for this though, so extra pairs of eyes etc. appreciated