### PR TITLE
Use simplecov instead of rcov.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -55,9 +55,8 @@ end
 
 desc "Generate RCov test coverage and open in your browser"
 task :coverage do
-  require 'rcov'
-  sh "rm -fr coverage"
-  sh "rcov test/test_*.rb"
+  ENV['COVERAGE'] = 'true'
+  Rake::Task['test'].invoke
   sh "open coverage/index.html"
 end
 

--- a/god.gemspec
+++ b/god.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('prowly', '~> 0.3')
   s.add_development_dependency('xmpp4r', '~> 0.5')
   s.add_development_dependency('dike', '~> 0.0.3')
- # s.add_development_dependency('rcov', '~> 0.9')
+  s.add_development_dependency('simplecov', '~> 0.9.1')
   s.add_development_dependency('daemons', '~> 1.1')
   s.add_development_dependency('mocha', '~> 0.10')
   s.add_development_dependency('gollum', '~> 1.3.1')

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,3 +1,8 @@
+if ENV['COVERAGE']
+  require 'simplecov'
+  SimpleCov.start
+end
+
 $:.unshift File.expand_path('../../lib', __FILE__) # For use/testing when no gem is installed
 
 # Use this flag to actually load all of the god infrastructure


### PR DESCRIPTION
This PR replaces rcov with simplecov, which supports ruby 2, as well as 1.9.3 and 1.8.7.

Tested with (bundle exec) `rake coverage` on ruby 2.1.2 and 1.9.3.

Set ENV['COVERAGE'] from the :coverage task, for backwards compatibility, though preferred way to run this would just be `COVERAGE=true bundle exec rake test`.

I wasn't able to get rcov running on master, so I couldn't compare the output of simplecov with the (old) rcov output, but the simplecov output seems reasonable.
