### PR TITLE
Always write pid file if specified in flags

### DIFF
--- a/lib/god/cli/run.rb
+++ b/lib/god/cli/run.rb
@@ -60,6 +60,10 @@ module God
         else
           God.log_level = @options[:daemonize] ? :warn : :info
         end
+        
+        if @options[:pid]
+          File.open(@options[:pid], 'w') { |f| f.write pid }
+        end
 
         if @options[:config]
           if !@options[:config].include?('*') && !File.exist?(@options[:config])
@@ -113,10 +117,6 @@ module God
             puts e.backtrace.join("\n")
             abort "There was a fatal system error while starting god (see above)"
           end
-        end
-
-        if @options[:pid]
-          File.open(@options[:pid], 'w') { |f| f.write pid }
         end
 
         ::Process.detach pid


### PR DESCRIPTION
When using a system init.d-like framework (in my case, launchd), it can be helpful to run god in the foreground and let the system daemonize it. In such cases, it is still useful to have the pid of the process available.