### PR TITLE
Explicitly catch NoMethodError instead of catching with Object when there are no events in queue

### DIFF
--- a/lib/god/driver.rb
+++ b/lib/god/driver.rb
@@ -179,7 +179,7 @@ module God
         loop do
           begin
             @events.pop.handle_event
-          rescue ThreadError => e
+          rescue ThreadError, NoMethodError => e
             # queue is empty
             break
           rescue Object => e
@@ -189,6 +189,7 @@ module God
           end
         end
       end
+      @thread.abort_on_exception = true
     end
 
     # Check if we're in the driver context.

--- a/test/test_driver.rb
+++ b/test/test_driver.rb
@@ -23,4 +23,12 @@ class TestDriver < Minitest::Test
 
     t.join
   end
+
+  def test_handle_empty_queue
+    task = God::Task.new
+    driver = God::Driver.new(task)
+
+    events = driver.instance_variable_get(:@events)
+    assert events.shutdown
+  end
 end


### PR DESCRIPTION
This can be replicated by loading a watch, stopping it, and removing it. 

The logs look like this 

    I [2015-03-23 08:17:03]  INFO: simple-app-0 sent SIGKILL
    I [2015-03-23 08:17:03]  INFO: simple-app-0 process stopped
    I [2015-03-23 08:17:03]  INFO: simple-app-0 move 'up' to 'unmonitored'
    I [2015-03-23 08:17:03]  INFO: simple-app-0 deregistered 'proc_exit' event for pid 4907
    I [2015-03-23 08:17:03]  INFO: simple-app-0 moved 'up' to 'unmonitored'
    F [2015-03-23 08:17:06] FATAL: Unhandled exception in driver loop - (NoMethodError): undefined         method `handle_event' for nil:NilClass
    /var/lib/gems/1.9.1/gems/god-0.13.5/lib/god/driver.rb:181:in `block (2 levels) in initialize'
    /var/lib/gems/1.9.1/gems/god-0.13.5/lib/god/driver.rb:179:in `loop'
    /var/lib/gems/1.9.1/gems/god-0.13.5/lib/god/driver.rb:179:in `block in initialize'
    I [2015-03-23 08:17:06]  INFO: simple-app-0 unwatched

The watch is a simple watch similar to the example on the homepage.

The test fails if you comment out the Object catch. 

