### PR TITLE
Fixed slack integration

### DIFF
--- a/lib/god/contacts/slack.rb
+++ b/lib/god/contacts/slack.rb
@@ -19,7 +19,7 @@ module God
 
     class Slack < Contact
       class << self
-        attr_accessor :account, :token, :channel, :notify_channel, :format, :username, :emoji
+        attr_accessor :url, :channel, :notify_channel, :format, :username, :emoji
       end
 
       self.channel        = "#general"
@@ -28,12 +28,11 @@ module God
 
       def valid?
         valid = true
-        valid &= complain("Attribute 'account' must be specified", self) unless arg(:account)
-        valid &= complain("Attribute 'token' must be specified", self) unless arg(:token)
+        valid &= complain("Attribute 'url' must be specified", self) unless arg(:url)
         valid
       end
 
-      attr_accessor :account, :token, :channel, :notify_channel, :format, :username, :emoji
+      attr_accessor :url, :channel, :notify_channel, :format, :username, :emoji
 
       def text(data)
         text = ""
@@ -63,7 +62,7 @@ module God
       end
 
       def api_url
-        URI.parse("https://#{arg(:account)}.slack.com/services/hooks/incoming-webhook?token=#{arg(:token)}")
+        URI.parse arg(:url)
       end
 
       def request(text)
@@ -97,4 +96,3 @@ module God
 
   end
 end
-

--- a/test/test_slack.rb
+++ b/test/test_slack.rb
@@ -3,8 +3,9 @@ require File.dirname(__FILE__) + '/helper'
 class TestSlack < Minitest::Test
   def setup
     @slack = God::Contacts::Slack.new
-    @slack.account = "foo"
-    @slack.token = "foo"
+
+    # new slack webhook url contains three random 'tokens' with length of 9, 9 and 24 characters
+    @slack.url = "https://hooks.slack.com/services/ABCABCABC/DEFDEFDEF/ABCDEFABCDEFABCDEFABCDEF"
 
     @sample_data = {
       :message => "a sample message",
@@ -16,7 +17,7 @@ class TestSlack < Minitest::Test
   end
 
   def test_api_url
-    assert_equal "https://foo.slack.com/services/hooks/incoming-webhook?token=foo", @slack.api_url.to_s
+    assert_equal @slack.url, @slack.api_url.to_s
   end
 
   def test_notify


### PR DESCRIPTION
Slack updated their incoming webhook API.
Account specific urls with token ( e.g. https://foo.slack.com/services/hooks/incoming-webhook?token=foo ) were removed and replaced with unique webhook url ( e.g. https://hooks.slack.com/services/ABCABCABC/DEFDEFDEF/ABCDEFABCDEFABCDEFABCDEF )