### PR TITLE
Update twitter gem v5.0+ which supports ruby 2.2

### DIFF
--- a/god.gemspec
+++ b/god.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rake')
   s.add_development_dependency('minitest')
   s.add_development_dependency('rdoc', '~> 3.10')
-  s.add_development_dependency('twitter', '~> 4.0')
+  s.add_development_dependency('twitter', '~> 5.0')
   s.add_development_dependency('prowly', '~> 0.3')
   s.add_development_dependency('xmpp4r', '~> 0.5')
   s.add_development_dependency('dike', '~> 0.0.3')


### PR DESCRIPTION
When launching god with ruby 2.2, the following warning appears: 

```sh
$ bundle exec god terminate
/usr/local/var/rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/twitter-4.8.1/lib/twitter/cursor.rb:51: warning: circular argument reference - collection
```

The series of v 4.x of the gem 'twitter' on which god depends doesn't support ruby 2.2 and the gem has started supporting ruby 2.2 since v 5.0+. 
