### PR TITLE
Fixing of incorrect comment

### DIFF
--- a/lib/god/conditions/socket_responding.rb
+++ b/lib/god/conditions/socket_responding.rb
@@ -52,7 +52,7 @@ module God
     #
     # on.condition(:socket_responding) do |c|
     #   c.family = 'unix'
-    #   c.port = '/tmp/sock'
+    #   c.path = '/tmp/sock'
     # end
     #
     class SocketResponding < PollCondition


### PR DESCRIPTION
Fixing of incorrect comment
# c.port = '/tmp/sock'
