### PR TITLE
Add the option to use a proc to modify the data being sent by a webhook 

### DIFF
--- a/test/test_webhook.rb
+++ b/test/test_webhook.rb
@@ -19,4 +19,18 @@ class TestWebhook < Minitest::Test
 
     @webhook.notify('msg', Time.now, 'prio', 'cat', 'host')
   end
+
+  def test_notify_with_process_data_callback
+    data_to_send = {:processed => true}
+    data_callback = proc do |message, time, priority, category, host|
+      data_to_send
+    end
+
+    @webhook.url = 'http://example.com/switch'
+    @webhook.format = :json
+    @webhook.process_data = data_callback
+    Net::HTTP.any_instance.expects(:request).with {|req| req.body == data_to_send.to_json }.returns(Net::HTTPSuccess.new('a', 'b', 'c'))
+
+    @webhook.notify('msg', Time.now, 'prio', 'cat', 'host')
+  end
 end


### PR DESCRIPTION
I have a use case where I would like to post a notification to a webhook, but I want to control the data being posted. This implements a `process_data` argument on the Webhook handler. This argument can be set to a proc data, which receives all 5 of the notify arguments, and returns the object that will be posted/sent as json.
