### PR TITLE
allow uri-inline basic auth

### DIFF
--- a/lib/god/contacts/webhook.rb
+++ b/lib/god/contacts/webhook.rb
@@ -46,12 +46,12 @@ module God
         req = nil
         res = nil
 
+        req = Net::HTTP::Post.new(uri.request_uri)
+        req.basic_auth(uri.user, uri.password) unless uri.user.nil? || uri.password.nil?
         case arg(:format)
           when :form
-            req = Net::HTTP::Post.new(uri.request_uri)
             req.set_form_data(data)
           when :json
-            req = Net::HTTP::Post.new(uri.request_uri)
             req.body = data.to_json
         end
 


### PR DESCRIPTION
This pull will set the user and password in the request (if both are defined in the given URI string.) It will allow webhooks that use basic auth instead of tokens. I also deduplicated the Net:HTTP:Post.new line so I wouldn't have to duplicate this change in both when blocks.
