### PR TITLE
Prevents god from resurrecting a keepalive process that has been stopped

### DIFF
--- a/lib/god/process.rb
+++ b/lib/god/process.rb
@@ -276,7 +276,10 @@ module God
             applog(self, :warn, "#{self.name} #{action} command exited with non-zero code = #{exit_code}")
           end
 
-          ensure_stop if action == :stop
+          if action == :stop
+            ensure_stop
+            return
+          end
         end
 
         if @tracking_pid or (@pid_file.nil? and WRITES_PID.include?(action))


### PR DESCRIPTION
Fixes #250, where god continues to monitor and resurrect a process after executing `god stop <task name>`. This particular issue occurs when using `keepalive`, a custom stop command using a `QUIT` signal, and a process that does not terminate within the `stop_timeout` period.

This commit forces a return after the execution of `ensure_stop` and prevents god from writing a new PID - the PID of a process spawned to run the custom stop command - and continuing to track the process which was previously killed.