### PR TITLE
timeout error fixed

### DIFF
--- a/lib/god/system/slash_proc_poller.rb
+++ b/lib/god/system/slash_proc_poller.rb
@@ -61,7 +61,7 @@ module God
       # read from them. Try to use this sparingly as it is expensive.
       def self.readable?(path)
         begin
-          timeout(1) { File.read(path) }
+          Timeout.timeout(1) { File.read(path) }
         rescue Timeout::Error
           false
         end


### PR DESCRIPTION
while deploying with capistrano god terminate & restart command were throwing this error

```
00:13 god:restart
01 RBENV_ROOT=$HOME/.rbenv RBENV_VERSION=2.7.1 $HOME/.rbenv/bin/rbenv exec bundle exec god terminate
01 Uncaught exception
01
01 undefined method `timeout' for God::System::SlashProcPoller:Class
01
01 (drbunix:///tmp/god.17165.sock) /myapp/shared/bundle/ruby/2.7.0/gems/god-0.13.7/lib/god/system/slash_proc_poller.rb:64:in `readable?'
```